### PR TITLE
Fix build on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 # CLion
-.idea
+.idea/
 
 # Build
-build
-release
+build/
+release/
 
 # Personal
-roms
+roms/
 docs

--- a/core/cpu/registers.h
+++ b/core/cpu/registers.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <array>
+#include <cstddef>
 #include <cstdint>
 
 #define REG_SP_INDEX 7

--- a/core/soc/rtc/rtc.cpp
+++ b/core/soc/rtc/rtc.cpp
@@ -1,7 +1,10 @@
+#define __STDC_WANT_LIB_EXT1__ 1
+
 #include "rtc.h"
 
 #include <chrono>
 #include <cmath>
+#include <ctime>
 
 #include "core/soc/defines.h"
 
@@ -48,7 +51,13 @@ void RTC::Cycle(uint8_t cycles)
 
         const time_t now = std::time(nullptr);
         std::tm current_time = {};
+#ifdef _WIN32  /* windows does something standard-non-compliant here... */
         localtime_s(&current_time, &now);
+#elif defined(__STDC_LIB_EXT1__)
+        localtime_s(&now, &current_time);
+#else
+        localtime_r(&now, &current_time);
+#endif
 
         RSECDR = BCD(current_time.tm_sec);
         RMINDR = BCD(current_time.tm_min);

--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 4.0)
 
 project(pocketwalker)
 
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
* `cstddef` missing in that one header caused `size_t` to not be found
* Windows gets the arguments to `localtime_s` wrong [compared to what the standard says](https://en.cppreference.com/c/chrono/localtime), sigh

I also changed the gitignore to be explicit about ignoring folders, because otherwise those lines would match files with those names too