### PR TITLE
Fix macOS build

### DIFF
--- a/core/soc/rtc/rtc.cpp
+++ b/core/soc/rtc/rtc.cpp
@@ -48,7 +48,11 @@ void RTC::Cycle(uint8_t cycles)
 
         const time_t now = std::time(nullptr);
         std::tm current_time = {};
+#ifdef _WIN32
         localtime_s(&current_time, &now);
+#else
+        localtime_r(&now, &current_time);
+#endif
 
         RSECDR = BCD(current_time.tm_sec);
         RMINDR = BCD(current_time.tm_min);

--- a/core/soc/sci3/sci3.h
+++ b/core/soc/sci3/sci3.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <queue>
 
 #include "core/soc/memory/regions/io.h"

--- a/core/utils/h8300h_ptr.h
+++ b/core/utils/h8300h_ptr.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <bit>
 #include <concepts>
+#include <cstddef>
+#include <cstdint>
 
 // provides an h8/300h big endian byte swap ptr for u16 and u32
 // holy moly this is ugly

--- a/desktop/src/main.cpp
+++ b/desktop/src/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <QApplication>
 #include <QStyleFactory>
+#include <QSurfaceFormat>
 
 #include "argparse/argparse.hpp"
 
@@ -9,6 +10,12 @@
 
 int main(int argc, char* argv[])
 {
+    QSurfaceFormat fmt;
+    fmt.setVersion(3, 3);
+    fmt.setProfile(QSurfaceFormat::CoreProfile);
+    fmt.setRenderableType(QSurfaceFormat::OpenGL);
+    QSurfaceFormat::setDefaultFormat(fmt);
+
     argparse::ArgumentParser arguments("pocketwalker");
 
     arguments.add_argument("rom")

--- a/desktop/src/qt/audio/qt_audio_system.cpp
+++ b/desktop/src/qt/audio/qt_audio_system.cpp
@@ -1,5 +1,6 @@
 #include "qt_audio_system.h"
 #include <QMediaDevices>
+#include <QThread>
 
 #include "desktop/src/qt/settings/app_settings.h"
 
@@ -20,7 +21,12 @@ QtAudioSystem::QtAudioSystem(QObject* parent) : QObject(parent)
 QtAudioSystem::~QtAudioSystem()
 {
     Flush();
+    sink->disconnect();
     sink->stop();
+    device = nullptr;
+    QThread::msleep(50);
+    delete sink;
+    sink = nullptr;
 }
 
 void QtAudioSystem::PushSample(BuzzerInformation info)

--- a/desktop/src/qt/emulator/emulator_context.cpp
+++ b/desktop/src/qt/emulator/emulator_context.cpp
@@ -48,6 +48,17 @@ EmulatorContext::~EmulatorContext()
     if (emulator_thread && emulator_thread->joinable())
         emulator_thread->join();
 
+    audio.reset();
+
+    if (network && network_thread && network_thread->isRunning())
+    {
+        QThread* main_thread = QThread::currentThread();
+        QMetaObject::invokeMethod(
+            network.get(),
+            [n = network.get(), main_thread]() { n->moveToThread(main_thread); },
+            Qt::BlockingQueuedConnection);
+    }
+
     if (network_thread)
     {
         network_thread->quit();


### PR DESCRIPTION
A few fixes to make builds work on macOS

1. Some headers are not transitively pulled in on macOS, they have to be included explicitly
2. `localtime` is different on macOS, same on Linux I believe
3. Need to explicitly request an openGL 3.3 context, or macOS gives you an old one that does not have all the functions you need
4. The audio system needs more time to shut down on macOS. I had Claude figure this out. The gist of it is that macOS CoreAudio is callback based, and sink->stop() does not synchronize with the OS-owned audio thread. So when sink gets immediately torn down by QT, in-flight audio callbacks can arrive on a partially torn-down thread, leading to segfault.
5. The changes to the teardown fix a warning on shutdown that QTimers can only be stopped by the thread they live on.